### PR TITLE
feat: generalize output dir for e2e example

### DIFF
--- a/contracts/src/blobstream/sp1_to_env.ts
+++ b/contracts/src/blobstream/sp1_to_env.ts
@@ -3,8 +3,10 @@ import fs from 'fs';
 const args = process.argv;
 
 const sp1Proof = args[2];
-const envPath = args[3];
-const proofName = args[4];
+const runDir = args[3];
+const workDir = args[4];
+const proofName = args[5];
+const envPath = `${runDir}/env.${proofName}`;
 
 const sp1 = JSON.parse(fs.readFileSync(sp1Proof, 'utf8'));
 const hexPi = Buffer.from(sp1.public_values.buffer.data).toString('hex');
@@ -12,8 +14,8 @@ const programVk = sp1.proof.Plonk.public_inputs[0];
 const encodedProof = sp1.proof.Plonk.encoded_proof;
 
 const env = `\
-WORK_DIR=blobstream_example/run/${proofName}/e2e_plonk
-CACHE_DIR=blobstream_example/run/plonk_cache
+WORK_DIR=${workDir}/${proofName}/e2e_plonk
+CACHE_DIR=${workDir}/plonk_cache
 HEX_PROOF="0x00000000${encodedProof}"
 PROGRAM_VK="${programVk}"
 HEX_PI="0x${hexPi}"

--- a/scripts/blobstream_example/e2e_blobstream_inclusion.sh
+++ b/scripts/blobstream_example/e2e_blobstream_inclusion.sh
@@ -3,7 +3,8 @@ set -e
 SCRIPT_DIR=$(dirname -- $(realpath $0)) 
 cd $SCRIPT_DIR/../..
 
-RUN_DIR=$SCRIPT_DIR/run
+RUN_DIR_RELATIVE_TO_SCRIPTS=$(basename $SCRIPT_DIR)/run
+RUN_DIR=$(pwd)/scripts/$RUN_DIR_RELATIVE_TO_SCRIPTS
 
 mkdir -p $RUN_DIR
 
@@ -24,7 +25,7 @@ npm install
 npm run build
 
 
-node "./build/src/blobstream/sp1_to_env.js" $SCRIPT_DIR/blobstreamSP1Proof.json $RUN_DIR/env.blobstream blobstream &
+node "./build/src/blobstream/sp1_to_env.js" $SCRIPT_DIR/blobstreamSP1Proof.json $RUN_DIR $RUN_DIR_RELATIVE_TO_SCRIPTS blobstream &
 
 node_pid=$!
 wait $node_pid
@@ -37,7 +38,7 @@ else
   exit 1
 fi
 
-node "./build/src/blobstream/sp1_to_env.js" $SCRIPT_DIR/blobInclusionSP1Proof.json $RUN_DIR/env.blobInclusion blobInclusion &
+node "./build/src/blobstream/sp1_to_env.js" $SCRIPT_DIR/blobInclusionSP1Proof.json $RUN_DIR $RUN_DIR_RELATIVE_TO_SCRIPTS blobInclusion &
 
 node_pid=$!
 wait $node_pid


### PR DESCRIPTION
Generalize the sp1_to_env environment setup and end-to-end example script so that a custom run directory can be specified to contain the environment, proof, and output files.