### PR TITLE
Dont use requireNothing

### DIFF
--- a/contracts/src/blobstream/blobstream_contract.ts
+++ b/contracts/src/blobstream/blobstream_contract.ts
@@ -50,7 +50,6 @@ export class BlobstreamProcessor extends SmartContract {
         let leafIndex = this.currentLeafIndex.getAndRequireEquals();
 
         let commitmentsRoot = this.commitmentsRoot.getAndRequireEquals();
-        this.commitmentsRoot.requireEquals(commitmentsRoot);
 
         path.calculateRoot(Field(0)).assertEquals(commitmentsRoot);
         const newRoot = path.calculateRoot(Poseidon.hash([

--- a/contracts/src/blobstream/blobstream_contract.ts
+++ b/contracts/src/blobstream/blobstream_contract.ts
@@ -47,10 +47,9 @@ export class BlobstreamProcessor extends SmartContract {
 
     @method async update(admin: PrivateKey, blobstreamProof: BlobstreamProofType, path: BlobstreamMerkleWitness) {
         blobstreamProof.verify()
-        let leafIndex = this.currentLeafIndex.get();
-        this.currentLeafIndex.requireEquals(leafIndex);
+        let leafIndex = this.currentLeafIndex.getAndRequireEquals();
 
-        let commitmentsRoot = this.commitmentsRoot.get();
+        let commitmentsRoot = this.commitmentsRoot.getAndRequireEquals();
         this.commitmentsRoot.requireEquals(commitmentsRoot);
 
         path.calculateRoot(Field(0)).assertEquals(commitmentsRoot);
@@ -58,7 +57,6 @@ export class BlobstreamProcessor extends SmartContract {
             ...blobstreamProof.publicInput.dataCommitment.toFields(),
         ]));
 
-        this.commitmentsRoot.requireNothing();
         this.commitmentsRoot.set(newRoot);
 
         this.currentLeafIndex.set(leafIndex.add(Field.from(1)));

--- a/contracts/src/blobstream/rollup.ts
+++ b/contracts/src/blobstream/rollup.ts
@@ -71,11 +71,9 @@ export class HelloWorldRollup extends SmartContract {
             ])
         ).assertEquals(blobstreamRoot);
 
-        const currentState = this.rollupState.get();
-        this.rollupState.requireEquals(currentState);
+        const currentState = this.rollupState.getAndRequireEquals();
         currentState.assertEquals(batcherProof.publicOutput.initialStateHash);
 
-        this.rollupState.requireNothing();
         this.rollupState.set(batcherProof.publicOutput.currentStateHash);
 
         const blobInclusionVkHash = this.blobInclusionVkHash.get();


### PR DESCRIPTION
Using `getAndRequireEquals` will create a precondition on the proof that the on-chain value matches the JS input.

Using `requireNothing` explicitly removes that precondition so any JS input will be valid.